### PR TITLE
Fix rsa version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,9 +1,9 @@
 cloudshell-shell-core>=4.0.0,<4.1.0
 cloudshell-cp-core>=1.0.0,<1.1.0
 cloudshell-automation-api>=9.1,<9.2
-rsa==4.0
 
 #should move to the ccp
+rsa==4.0
 google-api-python-client==1.7.8
 google-auth==1.6.2
 google-auth-httplib2==0.0.3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 cloudshell-shell-core>=4.0.0,<4.1.0
 cloudshell-cp-core>=1.0.0,<1.1.0
 cloudshell-automation-api>=9.1,<9.2
+rsa==4.0
 
 #should move to the ccp
 google-api-python-client==1.7.8


### PR DESCRIPTION
Previous RSA fails on installation from google-auth

```
Collecting rsa>=3.1.4 (from google-auth==1.6.2->-r C:\Users\CSadmin123456\Downloads\Google.Cloud.Provider\GcCloudProviderDriver\requirements.txt (line 7))
  Cache entry deserialization failed, entry ignored
  Downloading https://files.pythonhosted.org/packages/2d/d3/41b3db87f262debadb153900d4e6f8d61aa87187dd6fedd855ed24e8526d/rsa-4.7.1.tar.gz
Unknown requires Python '>=3.5, <4' but the running Python is 2.7.13
You are using pip version 9.0.1, however version 21.3.1 is available.
```